### PR TITLE
Dashmap for ArcIntern storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,9 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 
+dashmap = "3.11.9"
 lazy_static = "1.4.0"
+once_cell = "1.4"
 state = { version = "0.4.1", features = ["tls"] }
 tinyset = "0.4.2"
 hashbrown = { version = "0.8" }

--- a/src/boxedset.rs
+++ b/src/boxedset.rs
@@ -31,7 +31,7 @@ impl<P: Deref + Eq + Hash> HashSet<P> {
             .as_ref()
             .map(|kv| kv.0)
     }
-    pub fn take<Q: ?Sized + Hash + Eq>(&mut self, k: &Q) -> Option<P>
+    pub fn _take<Q: ?Sized + Hash + Eq>(&mut self, k: &Q) -> Option<P>
     where
         P: Borrow<Q>,
     {


### PR DESCRIPTION
This change updates ArcIntern's internal storage from Mutex<HashSet> to DashMap.  DashMap has sharded locks so this scales better when heavily contended from multiple threads.

This keeps the loop in ArcIntern::new() with the backoff if race between new and drop is encountered.   DashMap has remove_if() operation which perhaps could offer an alternative way to avoid the race in a later change.

I couldn't see a non-racy way to use the reader/write nature of DashMap's locks to gain further concurrency so this uses get_mut() which always obtains the shared write lock.

Another limitation is that I also couldn't find a Borrow implementation that would allow ArcIntern::from to keep its reference only get code path to call DashMap::get, so it for now ArcIntern::from() delegates to ArcIntern::new(). 

It also uses OnceCell to do the type map initialization as that's what I'd used in introducing DashMap to arc-interner and it seemed to work nicely.

