### PR TITLE
Fix crate name located in droundy/easybench-rs repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0", optional = true }
 [dev-dependencies]
 
 quickcheck = "^0.9.2"
-easybench = { version = "1.0.0", git = "https://github.com/droundy/easybench-rs" }
+scaling = { git = "https://github.com/droundy/easybench-rs" }
 rand = "0.7.2"
 arc-interner = "0.5"
 


### PR DESCRIPTION
Fixes #22. This was broken by https://github.com/droundy/easybench-rs/commit/7d7a5096df555c09e307608fbb2164cba7ba342b.