### PR TITLE
Clean up some Clippy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,7 +359,7 @@ impl<T: Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
         self.pointer
     }
     fn get_container() -> dashmap::mapref::one::Ref<'static, TypeId, Untyped> {
-        let type_map = ARC_CONTAINERS.get_or_init(|| DashMap::new());
+        let type_map = ARC_CONTAINERS.get_or_init(DashMap::new);
         // Prefer taking the read lock to reduce contention, only use entry api if necessary.
         let boxed = if let Some(boxed) = type_map.get(&TypeId::of::<T>()) {
             boxed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ impl<T: Eq + Hash + Send + Sync + 'static> Intern<T> {
         }
         let p: &'static T = Box::leak(Box::new(val));
         m.insert(p);
-        return Intern { pointer: p };
+        Intern { pointer: p }
     }
     /// Intern a value from a reference.
     ///
@@ -193,7 +193,7 @@ impl<T: Eq + Hash + Send + Sync + 'static> Intern<T> {
         }
         let p = Box::leak(Box::new(T::from(val)));
         m.insert(p);
-        return Intern { pointer: p };
+        Intern { pointer: p }
     }
     /// See how many objects have been interned.  This may be helpful
     /// in analyzing memory use.


### PR DESCRIPTION
```console
warning: unneeded `return` statement
   --> src/lib.rs:179:9
    |
179 |         return Intern { pointer: p };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `Intern { pointer: p }`
    |
    = note: `#[warn(clippy::needless_return)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: unneeded `return` statement
   --> src/lib.rs:196:9
    |
196 |         return Intern { pointer: p };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `Intern { pointer: p }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: redundant closure
   --> src/lib.rs:362:51
    |
362 |         let type_map = ARC_CONTAINERS.get_or_init(|| DashMap::new());
    |                                                   ^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `DashMap::new`
    |
    = note: `#[warn(clippy::redundant_closure)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
```