### PR TITLE
update dashmap dependency to pick up 4.x releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 
 parking_lot = "0.11.0"
-dashmap = { version = "3.11.9", optional = true }
+dashmap = { version = "4.0.2", optional = true }
 once_cell = "1.4"
 tinyset = { version = "0.4.2", optional =  true }
 hashbrown = { version = "0.9" }


### PR DESCRIPTION
dashmap 4.x ended up as a maintenence release rather than the lockless redesign they planned so this is not super exciting, but might as well keep current

tested with cargo test and cargo bench --features bench -- -Z unstable-options

benchmark runs seemed withing usual noise on my machine