### PR TITLE
Add ahash hasher to replicate dashmap 3.x hasher setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 
 parking_lot = "0.11.0"
+ahash = { version = "0.3.8", optional = true }
 dashmap = { version = "4.0.2", optional = true }
 once_cell = "1.4"
 tinyset = { version = "0.4.2", optional =  true }
@@ -35,7 +36,7 @@ arc-interner = { version = "0.5", optional = true }
 
 [features]
 
-arc = ["dashmap"]
+arc = ["ahash", "dashmap"]
 bench = ["arc", "arc-interner"]
 
 [dev-dependencies]


### PR DESCRIPTION
Pass explicit hasher to DashMap, using same version of ahash that dashmap 3.11.10 was using

This brings ArcIntern performance with dashmap 4.x performance close to dashmap 3.x.

Stats from runs on same hardware as droundy/internment#26 are now:

Run 1
ArcIntern<i64>::new       266ns (R²=0.999, 3525 iterations in 49 samples)
ArcIntern<u8>::new       259ns (R²=1.000, 3875 iterations in 50 samples)
ArcIntern<String>::new short   1.72619ms (R²=1.000, 6 iterations in 3 samples)
ArcIntern<String>::new  2.961003ms (R²=1.000, 6 iterations in 3 samples)
ArcIntern<String>::from  3.354354ms (R²=0.996, 6 iterations in 3 samples)
ArcIntern<String>::compare/hash    23.625µs (R²=0.999, 10 iterations in 4 samples)
ArcIntern<i64>::clone        15ns (R²=1.000, 66976 iterations in 80 samples)

arc_interner::ArcIntern<i64>::new       199ns (R²=0.992, 4655 iterations in 52 samples)
arc_interner::ArcIntern<u8>::new       199ns (R²=1.000, 5090 iterations in 53 samples)
arc_interner::ArcIntern<String>::new short   1.50779ms (R²=1.000, 6 iterations in 3 samples)
arc_interner::ArcIntern<String>::new  2.727395ms (R²=1.000, 6 iterations in 3 samples)
arc_interner::ArcIntern<String>::compare/hash    22.766µs (R²=1.000, 6 iterations in 3 samples)
arc_interner::ArcIntern<i64>::clone        50ns (R²=1.000, 20435 iterations in 68 samples)

Run 2
ArcIntern<i64>::new       233ns (R²=0.990, 444355 iterations in 100 samples)
ArcIntern<u8>::new       254ns (R²=0.990, 403105 iterations in 99 samples)
ArcIntern<String>::new short  1.959922ms (R²=0.993, 15 iterations in 5 samples)
ArcIntern<String>::new  3.142551ms (R²=0.994, 6 iterations in 3 samples)
ArcIntern<String>::from  3.350853ms (R²=0.993, 28 iterations in 7 samples)
ArcIntern<String>::compare/hash    34.397µs (R²=0.990, 12520 iterations in 63 samples)
ArcIntern<i64>::clone        16ns (R²=1.000, 60881 iterations in 79 samples)

arc_interner::ArcIntern<i64>::new       245ns (R²=0.991, 27626 iterations in 71 samples)
arc_interner::ArcIntern<u8>::new       226ns (R²=0.990, 6626 iterations in 56 samples)
arc_interner::ArcIntern<String>::new short  2.680359ms (R²=0.991, 6 iterations in 3 samples)
arc_interner::ArcIntern<String>::new  3.624346ms (R²=1.000, 6 iterations in 3 samples)
arc_interner::ArcIntern<String>::compare/hash    32.815µs (R²=0.992, 6 iterations in 3 samples)
arc_interner::ArcIntern<i64>::clone        61ns (R²=0.995, 16751 iterations in 66 samples)

Run 3
ArcIntern<i64>::new       211ns (R²=0.999, 4655 iterations in 52 samples)
ArcIntern<u8>::new       211ns (R²=0.991, 9465 iterations in 60 samples)
ArcIntern<String>::new short  1.504479ms (R²=0.992, 6 iterations in 3 samples)
ArcIntern<String>::new  3.415422ms (R²=0.996, 6 iterations in 3 samples)
ArcIntern<String>::from  3.201214ms (R²=0.995, 6 iterations in 3 samples)
ArcIntern<String>::compare/hash    17.691µs (R²=1.000, 15 iterations in 5 samples)
ArcIntern<i64>::clone        12ns (R²=0.996, 88817 iterations in 83 samples)

arc_interner::ArcIntern<i64>::new       165ns (R²=0.993, 5560 iterations in 54 samples)
arc_interner::ArcIntern<u8>::new       161ns (R²=1.000, 6070 iterations in 55 samples)
arc_interner::ArcIntern<String>::new short  1.561348ms (R²=0.996, 6 iterations in 3 samples)
arc_interner::ArcIntern<String>::new   2.48407ms (R²=0.992, 6 iterations in 3 samples)
arc_interner::ArcIntern<String>::compare/hash     18.47µs (R²=1.000, 6 iterations in 3 samples)
arc_interner::ArcIntern<i64>::clone        40ns (R²=0.999, 24980 iterations in 70 samples)

