### PR TITLE
In Intern::new compute the hash before acquiring the mutex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ ahash = { version = "0.3.8", optional = true }
 dashmap = { version = "4.0.2", optional = true }
 once_cell = { version = "1.4", optional = true }
 tinyset = { version = "0.4.2", optional =  true }
-hashbrown = { version = "0.9" }
+hashbrown = { version = "0.9", features = ["raw"] }
 serde = { version = "1.0", optional = true }
 
 arc-interner = { version = "0.5", optional = true }


### PR DESCRIPTION
So there's smaller lock contention.

This also unlocks an option to do partitioning by hash, which should
reduce contention greatly.