### PR TITLE
Bump ahash dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 
 parking_lot = "0.12.1"
-ahash = { version = "0.7.6", optional = true }
+ahash = { version = "0.8.5", optional = true }
 dashmap = { version = "5.4.0", optional = true }
 once_cell = { version = "1.4", optional = true }
 tinyset = { version = "0.4.2", optional =  true }


### PR DESCRIPTION
The previous version had a bug, and was yanked.