### PR TITLE
fix `deep_size_of_interned` always returns a fixed value (close #51)

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -2,7 +2,6 @@
 use crate::boxedset::HashSet;
 use std::borrow::Borrow;
 use std::hash::{Hash, Hasher};
-use std::ops::Deref;
 use std::sync::Mutex;
 
 /// A arena for storing interned data
@@ -46,8 +45,6 @@ pub struct Arena<T: ?Sized> {
 #[cfg(feature = "deepsize")]
 impl<T: ?Sized + deepsize::DeepSizeOf> deepsize::DeepSizeOf for Arena<T> {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
-        use deepsize::DeepSizeOf;
-
         let hashset = self.data.lock().unwrap();
         (*hashset).deep_size_of_children(context)
     }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -2,6 +2,7 @@
 use crate::boxedset::HashSet;
 use std::borrow::Borrow;
 use std::hash::{Hash, Hasher};
+use std::ops::Deref;
 use std::sync::Mutex;
 
 /// A arena for storing interned data
@@ -45,8 +46,10 @@ pub struct Arena<T: ?Sized> {
 #[cfg(feature = "deepsize")]
 impl<T: ?Sized + deepsize::DeepSizeOf> deepsize::DeepSizeOf for Arena<T> {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        use deepsize::DeepSizeOf;
+
         let hashset = self.data.lock().unwrap();
-        hashset.deep_size_of_children(context)
+        hashset.deref().deep_size_of_children(context)
     }
 }
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -49,7 +49,7 @@ impl<T: ?Sized + deepsize::DeepSizeOf> deepsize::DeepSizeOf for Arena<T> {
         use deepsize::DeepSizeOf;
 
         let hashset = self.data.lock().unwrap();
-        hashset.deref().deep_size_of_children(context)
+        (*hashset).deep_size_of_children(context)
     }
 }
 

--- a/src/boxedset.rs
+++ b/src/boxedset.rs
@@ -20,24 +20,24 @@ impl<P> HashSet<P> {
 #[cfg(feature = "deepsize")]
 impl<P: deepsize::DeepSizeOf> deepsize::DeepSizeOf for HashSet<&'static P> {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
-        let pointers = self.0.capacity() * size_of::<&'static P>();
+        let pointers = self.0.capacity() * std::mem::size_of::<&'static P>();
         let heap_memory = self
             .0
             .keys()
-            .map(|n| (**n).deep_size_of_children(context) + size_of::<P>())
+            .map(|n| (**n).deep_size_of_children(context) + std::mem::size_of::<P>())
             .sum::<usize>();
         pointers + heap_memory
     }
 }
 
 #[cfg(feature = "deepsize")]
-impl <P: deepsize::DeepSizeOf + ?Sized> deepsize::DeepSizeOf for HashSet<Box<P>> {
+impl<P: deepsize::DeepSizeOf + ?Sized> deepsize::DeepSizeOf for HashSet<Box<P>> {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
-        let pointers = self.0.capacity() * size_of::<Box<P>>();
+        let pointers = self.0.capacity() * std::mem::size_of::<Box<P>>();
         let heap_memory = self
             .0
             .keys()
-            .map(|n| (**n).deep_size_of_children(context) + size_of_val(&**n))
+            .map(|n| (**n).deep_size_of_children(context) + std::mem::size_of_val(&**n))
             .sum::<usize>();
         pointers + heap_memory
     }
@@ -77,6 +77,7 @@ impl<P: Deref + Eq + Hash> HashSet<P> {
     pub fn len(&self) -> usize {
         self.0.len()
     }
+    #[allow(dead_code)] // maybe unused without `deepsize` feature
     pub fn capacity(&self) -> usize {
         self.0.capacity()
     }

--- a/src/boxedset.rs
+++ b/src/boxedset.rs
@@ -30,6 +30,19 @@ impl<P: deepsize::DeepSizeOf> deepsize::DeepSizeOf for HashSet<&'static P> {
     }
 }
 
+#[cfg(feature = "deepsize")]
+impl <P: deepsize::DeepSizeOf + ?Sized> deepsize::DeepSizeOf for HashSet<Box<P>> {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        let pointers = self.0.capacity() * size_of::<Box<P>>();
+        let heap_memory = self
+            .0
+            .keys()
+            .map(|n| (**n).deep_size_of_children(context) + size_of_val(&**n))
+            .sum::<usize>();
+        pointers + heap_memory
+    }
+}
+
 impl<P: Deref + Eq + Hash> HashSet<P> {
     pub fn get<'a, Q: ?Sized + Eq + Hash>(&'a self, key: &Q) -> Option<&'a P>
     where

--- a/src/boxedset.rs
+++ b/src/boxedset.rs
@@ -18,13 +18,13 @@ impl<P> HashSet<P> {
 }
 
 #[cfg(feature = "deepsize")]
-impl<P: deepsize::DeepSizeOf> deepsize::DeepSizeOf for HashSet<P> {
+impl<P: deepsize::DeepSizeOf> deepsize::DeepSizeOf for HashSet<&'static P> {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
-        let pointers = self.0.capacity() * std::mem::size_of::<P>();
+        let pointers = self.0.capacity() * size_of::<&'static P>();
         let heap_memory = self
             .0
             .keys()
-            .map(|n| n.deep_size_of_children(context))
+            .map(|n| (**n).deep_size_of_children(context) + size_of::<P>())
             .sum::<usize>();
         pointers + heap_memory
     }
@@ -63,6 +63,9 @@ impl<P: Deref + Eq + Hash> HashSet<P> {
     }
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
     }
     #[cfg(feature = "bench")]
     pub fn clear(&mut self) {

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -418,20 +418,18 @@ impl<'de, T: Eq + Hash + Send + Sync + ?Sized + 'static + Deserialize<'de>> Dese
 
 #[cfg(test)]
 mod intern_tests {
-    use std::hash::Hash;
-
     use super::Intern;
     use super::{Borrow, Deref};
+    use std::hash::Hash;
 
     #[cfg(feature = "deepsize")]
     use super::INTERN_CONTAINERS;
     #[cfg(feature = "deepsize")]
     use crate::{boxedset::HashSet, deep_size_of_interned};
     #[cfg(feature = "deepsize")]
-    use std::sync::Arc;
-
-    #[cfg(feature = "deepsize")]
     use deepsize::{Context, DeepSizeOf};
+    #[cfg(feature = "deepsize")]
+    use std::sync::Arc;
 
     #[test]
     fn eq_string() {
@@ -614,9 +612,6 @@ mod intern_tests {
             std::mem::size_of::<&'static ArcInside>() * m.capacity()
         });
 
-        // 3 ArcInside has different hash values
-        INTERN_CONTAINERS.with(|m: &mut HashSet<&'static ArcInside>| assert_eq!(m.len(), 3));
-
         let interned_size = deep_size_of_interned::<ArcInside>();
 
         println!("string_size: {}", string_size);
@@ -624,6 +619,10 @@ mod intern_tests {
         println!("set_size: {}", set_size);
         println!("pointers_in_set_size: {}", pointers_in_set_size);
         println!("interned_size: {}", interned_size);
+
+        // 3 ArcInside has different hash values
+        INTERN_CONTAINERS.with(|m: &mut HashSet<&'static ArcInside>| assert_eq!(m.len(), 3));
+
         assert_eq!(
             interned_size,
             string_size + object_size + set_size + pointers_in_set_size

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -419,17 +419,19 @@ impl<'de, T: Eq + Hash + Send + Sync + ?Sized + 'static + Deserialize<'de>> Dese
 #[cfg(test)]
 mod intern_tests {
     use std::hash::Hash;
-    use std::sync::Arc;
 
+    use super::Intern;
     use super::{Borrow, Deref};
-    use super::{Intern, INTERN_CONTAINERS};
-    use crate::boxedset::HashSet;
+
+    #[cfg(feature = "deepsize")]
+    use super::INTERN_CONTAINERS;
+    #[cfg(feature = "deepsize")]
+    use crate::{boxedset::HashSet, deep_size_of_interned};
+    #[cfg(feature = "deepsize")]
+    use std::sync::Arc;
 
     #[cfg(feature = "deepsize")]
     use deepsize::{Context, DeepSizeOf};
-
-    #[cfg(feature = "deepsize")]
-    use crate::deep_size_of_interned;
 
     #[test]
     fn eq_string() {

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -523,8 +523,8 @@ mod intern_tests {
     #[test]
     fn test_deep_size() {
         let string1 = String::from("abcdefghijklmnopqrstuvwxyz");
-        let string2 = String::from("abcdefghijklmnopqrstuvwxyz");
-        let string3 = String::from("abcdefghijklmnopqrstuvwxyz");
+        let string2 = string1.clone();
+        let string3 = string1.clone();
         // 3 string are the same, interned only once
         let string_size = string1.deep_size_of();
 
@@ -532,10 +532,12 @@ mod intern_tests {
         let _ = Intern::new(string2);
         let _ = Intern::new(string3);
         // size of set
-        let set_size = INTERN_CONTAINERS.with(|m: &mut HashSet<&'static String>| size_of_val(m));
+        let set_size =
+            INTERN_CONTAINERS.with(|m: &mut HashSet<&'static String>| std::mem::size_of_val(m));
         // size of pointers in the set
-        let pointers_in_set_size = INTERN_CONTAINERS
-            .with(|m: &mut HashSet<&'static String>| size_of::<&'static String>() * m.capacity());
+        let pointers_in_set_size = INTERN_CONTAINERS.with(|m: &mut HashSet<&'static String>| {
+            std::mem::size_of::<&'static String>() * m.capacity()
+        });
 
         let interned_size = deep_size_of_interned::<String>();
         assert_eq!(interned_size, string_size + set_size + pointers_in_set_size);
@@ -596,33 +598,34 @@ mod intern_tests {
             pointer: a1.pointer.clone(),
         };
         // size of ArcInside, 16 bytes each
-        let object_size = size_of::<ArcInside>() * 3;
+        let object_size = std::mem::size_of::<ArcInside>() * 3;
 
         let _ = Intern::new(a1);
         let _ = Intern::new(a2);
         let _ = Intern::new(a3);
 
         // size of set
-        let set_size = INTERN_CONTAINERS.with(|m: &mut HashSet<&'static ArcInside>| size_of_val(m));
+        let set_size =
+            INTERN_CONTAINERS.with(|m: &mut HashSet<&'static ArcInside>| std::mem::size_of_val(m));
         // size of pointers in the set
         let pointers_in_set_size = INTERN_CONTAINERS.with(|m: &mut HashSet<&'static ArcInside>| {
-            size_of::<&'static ArcInside>() * m.capacity()
+            std::mem::size_of::<&'static ArcInside>() * m.capacity()
         });
 
         // 3 ArcInside has different hash values
         INTERN_CONTAINERS.with(|m: &mut HashSet<&'static ArcInside>| assert_eq!(m.len(), 3));
 
         let interned_size = deep_size_of_interned::<ArcInside>();
-        assert_eq!(
-            interned_size,
-            string_size + object_size + set_size + pointers_in_set_size
-        );
 
         println!("string_size: {}", string_size);
         println!("object_size: {}", object_size);
         println!("set_size: {}", set_size);
         println!("pointers_in_set_size: {}", pointers_in_set_size);
         println!("interned_size: {}", interned_size);
+        assert_eq!(
+            interned_size,
+            string_size + object_size + set_size + pointers_in_set_size
+        );
     }
 }
 

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -43,7 +43,6 @@ use tinyset::Fits64;
 /// assert_eq!(y, Intern::from("world"));
 /// assert_eq!(&*x, "hello"); // dereference a Intern like a pointer
 /// ```
-
 #[test]
 fn like_doctest_intern() {
     let x = Intern::new("hello".to_string());
@@ -409,7 +408,9 @@ impl<T: Eq + Hash + Send + Sync + Default + 'static> Default for Intern<T> {
 
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 #[cfg(feature = "serde")]
-impl<'de, T: Eq + Hash + Send + Sync + ?Sized + 'static + Deserialize<'de>> Deserialize<'de> for Intern<T> {
+impl<'de, T: Eq + Hash + Send + Sync + ?Sized + 'static + Deserialize<'de>> Deserialize<'de>
+    for Intern<T>
+{
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         T::deserialize(deserializer).map(|x: T| Self::new(x))
     }
@@ -417,9 +418,18 @@ impl<'de, T: Eq + Hash + Send + Sync + ?Sized + 'static + Deserialize<'de>> Dese
 
 #[cfg(test)]
 mod intern_tests {
+    use std::hash::Hash;
+    use std::sync::Arc;
+
     use super::{Borrow, Deref};
     use super::{Intern, INTERN_CONTAINERS};
     use crate::boxedset::HashSet;
+
+    #[cfg(feature = "deepsize")]
+    use deepsize::{Context, DeepSizeOf};
+
+    #[cfg(feature = "deepsize")]
+    use crate::deep_size_of_interned;
 
     #[test]
     fn eq_string() {
@@ -512,19 +522,107 @@ mod intern_tests {
     #[cfg(feature = "deepsize")]
     #[test]
     fn test_deep_size() {
-        use crate::deep_size_of_interned;
-        use deepsize::DeepSizeOf;
+        let string1 = String::from("abcdefghijklmnopqrstuvwxyz");
+        let string2 = String::from("abcdefghijklmnopqrstuvwxyz");
+        let string3 = String::from("abcdefghijklmnopqrstuvwxyz");
+        // 3 string are the same, interned only once
+        let string_size = string1.deep_size_of();
 
-        let string = String::from("abcdefghijklmnopqrstuvwxyz");
-        let string_size = string.deep_size_of();
-
-        let _ = Intern::new(string);
+        let _ = Intern::new(string1);
+        let _ = Intern::new(string2);
+        let _ = Intern::new(string3);
+        // size of set
         let set_size = INTERN_CONTAINERS.with(|m: &mut HashSet<&'static String>| size_of_val(m));
+        // size of pointers in the set
         let pointers_in_set_size = INTERN_CONTAINERS
             .with(|m: &mut HashSet<&'static String>| size_of::<&'static String>() * m.capacity());
 
         let interned_size = deep_size_of_interned::<String>();
         assert_eq!(interned_size, string_size + set_size + pointers_in_set_size);
+    }
+
+    #[cfg(feature = "deepsize")]
+    #[derive(Clone)]
+    struct ArcInside {
+        hash: usize,
+        pointer: Arc<String>,
+    }
+
+    #[cfg(feature = "deepsize")]
+    impl Hash for ArcInside {
+        /// For testing purposes, we only hash the hash field.
+        /// In order to make [`ArcInside`] instances containing the same string have different hash values.
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            self.hash.hash(state);
+        }
+    }
+
+    #[cfg(feature = "deepsize")]
+    impl PartialEq for ArcInside {
+        /// For testing purposes, we only compare the hash field.
+        fn eq(&self, other: &Self) -> bool {
+            self.hash == other.hash
+        }
+    }
+
+    #[cfg(feature = "deepsize")]
+    impl Eq for ArcInside {}
+
+    #[cfg(feature = "deepsize")]
+    impl DeepSizeOf for ArcInside {
+        fn deep_size_of_children(&self, context: &mut Context) -> usize {
+            self.pointer.deep_size_of_children(context)
+        }
+    }
+
+    #[cfg(feature = "deepsize")]
+    #[test]
+    fn test_deep_size_with_context() {
+        let string = String::from("abcdefghijklmnopqrstuvwxyz");
+        // size of string inside arc, 50 bytes.
+        // Three arcs pointed to the same string will not be counted multiple times.
+        let string_size = string.deep_size_of();
+
+        let a1 = ArcInside {
+            hash: 1,
+            pointer: Arc::new(string),
+        };
+        let a2 = ArcInside {
+            hash: 2,
+            pointer: a1.pointer.clone(),
+        };
+        let a3 = ArcInside {
+            hash: 3,
+            pointer: a1.pointer.clone(),
+        };
+        // size of ArcInside, 16 bytes each
+        let object_size = size_of::<ArcInside>() * 3;
+
+        let _ = Intern::new(a1);
+        let _ = Intern::new(a2);
+        let _ = Intern::new(a3);
+
+        // size of set
+        let set_size = INTERN_CONTAINERS.with(|m: &mut HashSet<&'static ArcInside>| size_of_val(m));
+        // size of pointers in the set
+        let pointers_in_set_size = INTERN_CONTAINERS.with(|m: &mut HashSet<&'static ArcInside>| {
+            size_of::<&'static ArcInside>() * m.capacity()
+        });
+
+        // 3 ArcInside has different hash values
+        INTERN_CONTAINERS.with(|m: &mut HashSet<&'static ArcInside>| assert_eq!(m.len(), 3));
+
+        let interned_size = deep_size_of_interned::<ArcInside>();
+        assert_eq!(
+            interned_size,
+            string_size + object_size + set_size + pointers_in_set_size
+        );
+
+        println!("string_size: {}", string_size);
+        println!("object_size: {}", object_size);
+        println!("set_size: {}", set_size);
+        println!("pointers_in_set_size: {}", pointers_in_set_size);
+        println!("interned_size: {}", interned_size);
     }
 }
 


### PR DESCRIPTION
fix #51 
And fix a compile error when `arena` and `deepsize` are enabled at the same time.