### PR TITLE
Add some AsRef impls

### DIFF
--- a/src/intern.rs
+++ b/src/intern.rs
@@ -3,9 +3,11 @@ use super::boxedset;
 use boxedset::HashSet;
 use std::borrow::Borrow;
 use std::convert::AsRef;
+use std::ffi::OsStr;
 use std::fmt::{Debug, Display, Pointer};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
+use std::path::Path;
 
 use super::container;
 
@@ -326,6 +328,22 @@ impl<T: ?Sized> AsRef<T> for Intern<T> {
         self.pointer
     }
 }
+
+macro_rules! impl_as_ref {
+    ($from:ty => $to:ty) => {
+        impl AsRef<$to> for Intern<$from> {
+            #[inline(always)]
+            fn as_ref(&self) -> &$to {
+                self.pointer.as_ref()
+            }
+        }
+    };
+}
+
+impl_as_ref!(str => OsStr);
+impl_as_ref!(str => Path);
+impl_as_ref!(OsStr => Path);
+impl_as_ref!(Path => OsStr);
 
 impl<T: Eq + Hash + Send + Sync + ?Sized> Deref for Intern<T> {
     type Target = T;

--- a/src/typearena.rs
+++ b/src/typearena.rs
@@ -1,7 +1,9 @@
 #![deny(missing_docs)]
 use std::any::Any;
 use std::any::TypeId;
+use std::ffi::OsStr;
 use std::hash::{Hash, Hasher};
+use std::path::Path;
 
 use append_only_vec::AppendOnlyVec;
 
@@ -367,6 +369,22 @@ impl<T: ?Sized> AsRef<T> for Intern<T> {
         self.pointer
     }
 }
+
+macro_rules! impl_as_ref {
+    ($from:ty => $to:ty) => {
+        impl AsRef<$to> for Intern<$from> {
+            #[inline(always)]
+            fn as_ref(&self) -> &$to {
+                self.pointer.as_ref()
+            }
+        }
+    };
+}
+
+impl_as_ref!(str => OsStr);
+impl_as_ref!(str => Path);
+impl_as_ref!(OsStr => Path);
+impl_as_ref!(Path => OsStr);
 
 impl<T: Eq + Hash + Send + Sync + ?Sized> Deref for Intern<T> {
     type Target = T;


### PR DESCRIPTION
Sadly, you can't just replace
```rust
impl<T: ?Sized> AsRef<T> for Intern<T>
```
with
```rust
impl<T: ?Sized, U: ?Sized> AsRef<U> for Intern<T>
where
   T: AsRef<U>
```
because there is no `impl<T: ?Sized> AsRef<T> for T` in std.

But we can at least manually mirror some of [the implementations from std](https://doc.rust-lang.org/stable/std/convert/trait.AsRef.html#implementors). 