### PR TITLE
Cargo: use "dep:.." syntax for optional dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,12 @@ append-only-vec = { version = "0.1.2", optional = true }
 
 [features]
 
-arc = ["ahash", "dashmap", "once_cell"]
-bench = ["arc", "arc-interner", "arena", "memorable-wordlist", "append-only-vec"]
+arc = ["dep:ahash", "dep:dashmap", "dep:once_cell"]
+bench = ["arc", "arena", "_experimental-new-intern", "dep:memorable-wordlist"]
 arena = []
 intern = []
 default = ["intern"]
+_experimental-new-intern = ["dep:append-only-vec"]
 
 [dev-dependencies]
 quickcheck = "^0.9.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,11 +48,11 @@
 
 mod boxedset;
 
-#[cfg(feature = "append-only-vec")]
+#[cfg(feature = "_experimental-new-intern")]
 mod typearena;
 
 #[doc(hidden)]
-#[cfg(feature = "append-only-vec")]
+#[cfg(feature = "_experimental-new-intern")]
 pub use typearena::Intern as NewIntern;
 
 #[cfg(feature = "intern")]


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies

This has been ok since 1.60. The current MSRV is 1.70.

This makes it so that the users of interment do not get bombarded with features that aren't really crate's features, but rather its feature-gated dependencies.
![image](https://github.com/user-attachments/assets/f0064c02-a32a-41be-ad97-5d3ba52dc7d8)
