### PR TITLE
ArcIntern: add from_str() specialization for ArcIntern<String>

### DIFF
--- a/benches/get_container.rs
+++ b/benches/get_container.rs
@@ -14,6 +14,8 @@ struct NewType<T>(T);
 
 fn bench_get_container(c: &mut Criterion) {
     let mut group = c.benchmark_group("cached");
+    let vals: Vec<_> = (0..RANGE).map(|idx| format!("short-{}", idx)).collect();
+
     // time:   [17.635 ms 17.707 ms 17.782 ms]
     group.bench_function(BenchmarkId::new("String", "short"), |b| {
         b.iter_batched(
@@ -21,7 +23,7 @@ fn bench_get_container(c: &mut Criterion) {
             |_| {
                 let mut ans = Vec::with_capacity(ITER);
                 for idx in 0..ITER {
-                    let s = ArcIntern::<String>::new(format!("short-{}", idx % RANGE));
+                    let s = ArcIntern::<String>::new(vals[idx % RANGE].clone());
                     ans.push(s);
                 }
             },
@@ -30,6 +32,9 @@ fn bench_get_container(c: &mut Criterion) {
     });
     group.finish();
 
+    let new_vals: Vec<_> = (0..RANGE)
+        .map(|idx| NewType(format!("short-{}", idx)))
+        .collect();
     let mut group = c.benchmark_group("uncached");
     // time:   [22.209 ms 22.294 ms 22.399 ms] => that's 26% faster!
     group.bench_function(BenchmarkId::new("NewType<String>", "short"), |b| {
@@ -38,10 +43,7 @@ fn bench_get_container(c: &mut Criterion) {
             |_| {
                 let mut ans = Vec::with_capacity(ITER);
                 for idx in 0..ITER {
-                    let s = ArcIntern::<NewType<String>>::new(NewType(format!(
-                        "short-{}",
-                        idx % RANGE
-                    )));
+                    let s = ArcIntern::<NewType<String>>::new(new_vals[idx % RANGE].clone());
                     ans.push(s);
                 }
             },

--- a/benches/get_container.rs
+++ b/benches/get_container.rs
@@ -30,6 +30,35 @@ fn bench_get_container(c: &mut Criterion) {
             criterion::BatchSize::PerIteration,
         );
     });
+    group.bench_function(BenchmarkId::new("String", "short-from_ref"), |b| {
+        b.iter_batched(
+            || {},
+            |_| {
+                let mut ans = Vec::with_capacity(ITER);
+                for idx in 0..ITER {
+                    let s = ArcIntern::<String>::from_ref(&vals[idx % RANGE]);
+
+                    ans.push(s);
+                }
+            },
+            criterion::BatchSize::PerIteration,
+        );
+    });
+
+    group.bench_function(BenchmarkId::new("String", "short-from_str"), |b| {
+        b.iter_batched(
+            || {},
+            |_| {
+                let mut ans = Vec::with_capacity(ITER);
+                for idx in 0..ITER {
+                    let s = ArcIntern::<String>::from_str(&vals[idx % RANGE]);
+
+                    ans.push(s);
+                }
+            },
+            criterion::BatchSize::PerIteration,
+        );
+    });
     group.finish();
 
     let new_vals: Vec<_> = (0..RANGE)

--- a/benches/get_container.rs
+++ b/benches/get_container.rs
@@ -19,7 +19,7 @@ fn bench_get_container(c: &mut Criterion) {
         b.iter_batched(
             || {},
             |_| {
-                let mut ans = Vec::with_capacity(RANGE);
+                let mut ans = Vec::with_capacity(ITER);
                 for idx in 0..ITER {
                     let s = ArcIntern::<String>::new(format!("short-{}", idx % RANGE));
                     ans.push(s);
@@ -36,7 +36,7 @@ fn bench_get_container(c: &mut Criterion) {
         b.iter_batched(
             || {},
             |_| {
-                let mut ans = Vec::with_capacity(RANGE);
+                let mut ans = Vec::with_capacity(ITER);
                 for idx in 0..ITER {
                     let s = ArcIntern::<NewType<String>>::new(NewType(format!(
                         "short-{}",
@@ -54,7 +54,7 @@ fn bench_get_container(c: &mut Criterion) {
         b.iter_batched(
             || {},
             |_| {
-                let mut ans = Vec::with_capacity(RANGE);
+                let mut ans = Vec::with_capacity(ITER);
                 for idx in 0..ITER {
                     let s = ArcIntern::<usize>::new(idx % RANGE);
                     ans.push(s);
@@ -68,7 +68,7 @@ fn bench_get_container(c: &mut Criterion) {
         b.iter_batched(
             || {},
             |_| {
-                let mut ans = Vec::with_capacity(RANGE);
+                let mut ans = Vec::with_capacity(ITER);
                 for idx in 0..ITER {
                     let s = ArcIntern::<NewType<usize>>::new(NewType(idx % RANGE));
                     ans.push(s);

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -123,6 +123,14 @@ impl<T: ?Sized> Borrow<RefCount<T>> for BoxRefCount<T> {
         &self.0
     }
 }
+
+impl<T: ?Sized + BorrowStr> Borrow<str> for BoxRefCount<T> {
+    #[inline(always)]
+    fn borrow(&self) -> &str {
+        &self.0.data.borrow()
+    }
+}
+
 impl<T: ?Sized> Deref for BoxRefCount<T> {
     type Target = T;
     #[inline(always)]
@@ -259,6 +267,60 @@ impl<T: Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
             // and then we will be able to intern a new copy.
             std::thread::yield_now();
         }
+    }
+}
+
+/// internal trait that allows us to specialize the `Borrow` trait for `str`
+/// avoid the need to create an owned value first.
+pub trait BorrowStr: Borrow<str> {}
+
+impl BorrowStr for String {}
+
+/// BorrowStr specialization
+impl<T: ?Sized + Eq + Hash + Send + Sync + 'static> ArcIntern<T> {
+    /// Intern a value from a reference with atomic reference counting.
+    ///
+    /// this is a fast-path for str, as it avoids the need to create owned
+    /// value first.
+    pub fn from_str<Q: AsRef<str>>(val: Q) -> ArcIntern<T>
+    where
+        T: BorrowStr + for<'a> From<&'a str>,
+    {
+        // No reference only fast-path as
+        // the trait `std::borrow::Borrow<Q>` is not implemented for `Arc<T>`
+        Self::new_from_str(val.as_ref())
+    }
+
+    /// Intern a value from a reference with atomic reference counting.
+    ///
+    /// If this value has not previously been
+    /// interned, then `new` will allocate a spot for the value on the
+    /// heap and generate that value using `T::from(val)`.
+    fn new_from_str<'a>(val: &'a str) -> ArcIntern<T>
+    where
+        T: BorrowStr + From<&'a str>,
+    {
+        let m = Self::get_container();
+        if let Some(b) = m.get(val) {
+            let b = b.key();
+            // First increment the count.  We are holding the write mutex here.
+            // Has to be the write mutex to avoid a race
+            let oldval = b.0.count.fetch_add(1, Ordering::SeqCst);
+            if oldval != 0 {
+                // we can only use this value if the value is not about to be freed
+                return ArcIntern {
+                    pointer: std::ptr::NonNull::from(b.0.borrow()),
+                };
+            } else {
+                // we have encountered a race condition here.
+                // we will just wait for the object to finish
+                // being freed.
+                b.0.count.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+
+        // start over with the new value
+        Self::new(val.into())
     }
 }
 
@@ -625,4 +687,15 @@ fn test_shrink_to_fit() {
     assert!(ArcIntern::<Value>::get_container().capacity() >= 1);
     ArcIntern::<Value>::shrink_to_fit();
     assert_eq!(0, ArcIntern::<Value>::get_container().capacity());
+}
+
+#[test]
+fn test_from_str() {
+    let x = ArcIntern::new("hello".to_string());
+    let y = ArcIntern::<String>::from_str("world");
+    assert_ne!(x, y);
+    assert_eq!(x, ArcIntern::from_ref("hello"));
+    assert_eq!(x, ArcIntern::from_str("hello"));
+    assert_eq!(y, ArcIntern::from_ref("world"));
+    assert_eq!(&*x, "hello");
 }


### PR DESCRIPTION
This is useful in order to allow looking for interned str without having to create owned value first.

simple benchmarks show nice improvement in case the str was already interned:
```
    cached/String/short     time:   [13.598 ms 13.783 ms 13.994 ms]
                            change: [-0.5323% +1.5518% +3.7562%] (p = 0.15 > 0.05)
                            No change in performance detected.
    Found 14 outliers among 100 measurements (14.00%)
      7 (7.00%) high mild
      7 (7.00%) high severe
    cached/String/short-from_ref
                            time:   [13.582 ms 13.757 ms 13.955 ms]
                            change: [-1.5349% +0.4010% +2.5499%] (p = 0.70 > 0.05)
                            No change in performance detected.
    Found 12 outliers among 100 measurements (12.00%)
      3 (3.00%) high mild
      9 (9.00%) high severe
    cached/String/short-from_str
                            time:   [9.3047 ms 9.4529 ms 9.6175 ms]
                            change: [-1.9867% +0.4488% +2.9423%] (p = 0.72 > 0.05)
                            No change in performance detected.
    Found 15 outliers among 100 measurements (15.00%)
```

if the string is not interned we do end up with additional lookup, but other functions (`new`/`from_ref`) can be used if that's an issue. 