### PR TITLE
Add `no_std` and `no_alloc` support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
+          targets: "x86_64-unknown-none, thumbv6m-none-eabi"
       - run: cargo check --features "arc,tinyset"
+      - run: cargo check --no-default-features --target x86_64-unknown-none --features serde,arena,spin,intern,alloc,deepsize
+      - run: cargo check --no-default-features --target thumbv6m-none-eabi --features serde,arena,spin,intern,portable-atomic,critical-section
 
   test:
     name: Test Suite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ categories = ["caching", "memory-management", "concurrency"]
 keywords = ["hash", "interning", "hashconsing", "caching", "interner"]
 rust-version = "1.70"
 
+# Ensures dev-dependencies to enable features on standard dependencies unless compiling examples,
+# tests, etc.
+resolver = "2"
+
 [badges]
 
 appveyor = { repository = "droundy/internment" }
@@ -31,25 +35,33 @@ once_cell = { version = "1.4", optional = true }
 tinyset = { version = "0.4.2", optional =  true }
 memorable-wordlist = { version = "0.1.7", optional = true }
 hashbrown = { version = "0.15.0" }
-serde = { version = "1.0", optional = true }
-deepsize = { version = "0.2.0", optional = true }
+serde = { version = "1.0", optional = true, default-features = false }
+deepsize = { version = "0.2.0", optional = true, default-features = false }
 
 arc-interner = { version = "0.7", optional = true }
 
 append-only-vec = { version = "0.1.2", optional = true }
 
+spin = { version = "0.9.8", default-features = false, optional = true, features = [
+  "spin_mutex",
+] }
+portable-atomic = { version = "1", default-features = false, optional = true }
 
 [features]
 
-arc = ["dep:ahash", "dep:dashmap", "dep:once_cell"]
+arc = ["std", "dep:ahash", "dep:dashmap", "dep:once_cell"]
 bench = ["arc", "arena", "_experimental-new-intern", "dep:memorable-wordlist"]
-arena = []
-intern = []
-default = ["intern"]
-_experimental-new-intern = ["dep:append-only-vec"]
+arena = ["alloc"]
+intern = ["alloc"]
+default = ["intern", "std"]
+_experimental-new-intern = ["alloc", "dep:append-only-vec"]
+std = ["alloc"]
+alloc = ["serde?/alloc"]
+tinyset = ["std", "dep:tinyset"]
+portable-atomic = ["dep:portable-atomic", "spin?/portable_atomic"]
+critical-section = ["portable-atomic?/critical-section"]
 
 [dev-dependencies]
-quickcheck = "^0.9.2"
 scaling = "0.1.3"
 rand = "0.7.2"
 serde_json = "1.0.87"

--- a/src/boxedset.rs
+++ b/src/boxedset.rs
@@ -1,9 +1,13 @@
-use core::ops::Deref;
-use hashbrown::HashMap;
-use std::{
+use core::{
     borrow::Borrow,
     hash::{BuildHasher, Hash, Hasher},
+    ops::Deref,
 };
+use hashbrown::HashMap;
+
+#[cfg(all(feature = "deepsize", feature = "alloc"))]
+use alloc::boxed::Box;
+
 pub struct HashSet<P>(HashMap<P, ()>);
 
 impl<P: Deref + Eq + Hash> Default for HashSet<P> {
@@ -22,24 +26,24 @@ impl<P> HashSet<P> {
 #[cfg(feature = "deepsize")]
 impl<P: deepsize::DeepSizeOf> deepsize::DeepSizeOf for HashSet<&'static P> {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
-        let pointers = self.0.capacity() * std::mem::size_of::<&'static P>();
+        let pointers = self.0.capacity() * core::mem::size_of::<&'static P>();
         let heap_memory = self
             .0
             .keys()
-            .map(|n| (**n).deep_size_of_children(context) + std::mem::size_of::<P>())
+            .map(|n| (**n).deep_size_of_children(context) + core::mem::size_of::<P>())
             .sum::<usize>();
         pointers + heap_memory
     }
 }
 
-#[cfg(feature = "deepsize")]
+#[cfg(all(feature = "deepsize", feature = "alloc"))]
 impl<P: deepsize::DeepSizeOf + ?Sized> deepsize::DeepSizeOf for HashSet<Box<P>> {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
-        let pointers = self.0.capacity() * std::mem::size_of::<Box<P>>();
+        let pointers = self.0.capacity() * core::mem::size_of::<Box<P>>();
         let heap_memory = self
             .0
             .keys()
-            .map(|n| (**n).deep_size_of_children(context) + std::mem::size_of_val(&**n))
+            .map(|n| (**n).deep_size_of_children(context) + core::mem::size_of_val(&**n))
             .sum::<usize>();
         pointers + heap_memory
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,13 @@
 // Enable the `doc_cfg` feature when the `docsrs` configuration attribute is
 // defined
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 mod boxedset;
 


### PR DESCRIPTION
# Objective

- Add support for `no_std` and `no_alloc`
- Allow using `internment` on targets such as `x86_64-unknown-none` and `thumbv6m-none-eabi`

## Solution

- Added `#[no_std]` unconditionally [^1]
- Re-introduced `std` and `alloc` when features of the same names are enabled.
- Added `std` and `alloc` as required features of all features which fail to compile without them.
- Changed imports to pull from `core` and/or `alloc` as required.
- Added `spin` feature to provide a [`spin`](https://crates.io/crates/spin) based alternative to `std::sync::Mutex` [^2]
- Added `portable-atomic` and `critical-section` features to allow [`portable-atomic`](https://crates.io/crates/portable-atomic) to provide compatibility to atomically challenged platforms such as `thumbv6m-none-eabi` [^3]
- Switched to `resolver = "2"` to ensure `dev-dependencies` don't enable `std` on `serde` [^4]

[^1]: Adding `#[no_std]` using something like `#![cfg_attr(not(feature = "std"), no_std)]` will cause the implicit prelude to change based on the features used, which can make development harder than it needs to be.
[^2]: If the library is compiled _without_ `std` or `spin` a `compile_error!` is thrown indicating the user must enable one of those features. This allows the `spin` dependency to only come into the `Cargo.lock` if it is explicitly enabled.
[^3]: Keeping this as an optional feature ensures it is only included in `Cargo.lock` when explicitly enabled.
[^4]: Without `resolver = "2"`, feature unification causes the features enabled by `dev-dependencies` to be included in normal `dependencies`, which makes `no_std` support impossible without removing examples, benches, and/or tests.

## Testing

- `cargo check --no-default-features --target x86_64-unknown-none --features serde,arena,spin,intern,alloc,deepsize`
- `cargo check --no-default-features --target thumbv6m-none-eabi --features serde,arena,spin,intern,portable-atomic,critical-section`

## Release Notes

`internment` can now be used on `no_std` platforms. Simply disable default features, and enable any optional extras which themselves don't enable the new `std` feature:

```toml
internment = { version = "X.Y.Z", default-features = false, features = [
    "spin", # Required for `no_std` targets
    "serde",
    "intern",
    "deepsize",
    "arena",
# Incompatible with `no_std`
#  "arc",
#  "tinyset",
]}
```

If you are compiling for a target without full support for Rust atomics, you may need to enable the `portable-atomic` and `critical-section` features which aid in platform compatibility.

```toml
internment = { version = "X.Y.Z", default-features = false, features = [
    "spin", # Required for `no_std` targets
    "portable-atomic", # Required for atomically challenged platforms
    "critical-section", # Often required for atomically challenged platforms
    "serde",
    "intern",
    "arena",
# Incompatible with `no_std` on atomically challenged platforms
#  "deepsize",
#  "arc",
#  "tinyset",
]}
```

## Notes

- Based on `cargo msrv`, I believe these changes do not increase the MSRV of this crate.
- This PR is motivated by the possibility of including this crate in [Bevy](https://github.com/bevyengine/bevy). Our current implementation has broad support for `no_std` platforms, so this is a prerequisite for our usage of `internment`. I also believe adding this support is generally beneficial for the broader Rust community without substantially increasing maintenance burden on crate maintainers.
- This is my first contribution to this project. _Please_ let me know if there's anything I can do to assist with reviewing this PR.
- It may be prudent to add `x86_64-unknown-none` and `thumbv6m-none-eabi` targets to your CI tests with the relevant features enabled/disabled to ensure compatibility does not regress. I am not familiar with this particular CI system so I'd rather leave that out of this PR, but I am happy to investigate adding it if that's desirable!